### PR TITLE
reformats the response stuff as an array so errors array is properly …

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -48,6 +48,21 @@ class PBS_Media_Manager_API_Client {
     return $ch;
   }
 
+  private function make_response_array($response) {
+    $myarray=array();
+    $data=explode("\n",$response);
+    $myarray['status']=$data[0];
+    array_shift($data);
+    foreach($data as $part){
+      if (json_decode($part)) {
+        $myarray[] = json_decode($part);
+        continue;
+      }
+      $middle=explode(": ",$part,2);
+      $myarray[trim($middle[0])] = trim($middle[1]);
+    }
+    return $myarray;
+  }
 
   public function get_request($query) {
     $return = array();
@@ -60,6 +75,7 @@ class PBS_Media_Manager_API_Client {
     curl_close ($ch);
     $json = json_decode($result, true);
     if (empty($json)) {
+      $result = $this->make_response_array($result);
       return array('errors' => array('info' => $info, 'response' => $result));
     }
     if ($info['http_code'] != 200) {
@@ -95,6 +111,7 @@ class PBS_Media_Manager_API_Client {
     $errors = curl_error($ch);
     curl_close ($ch);
     if (!in_array($info['http_code'], array(200, 201, 202, 204))) {
+      $result = $this->make_response_array($result);
       return array('errors' => array('errors' => $errors, 'result' => $result));
     }
     /* successful request will return a 20x and the location of the created object


### PR DESCRIPTION
@augustuswm @acrosman I added a helper function to make for more useful error logging.  Right now, if something fails, the errors array includes the raw cURL response, which has newlines, and also half the time has an additional json object at the end of it.  This would make sure that the 'response' section of the error return is an actual array.