### PR TITLE
Fixed get_list_data to account for NULL args by forcing them to be ar…

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -191,6 +191,12 @@ class PBS_Media_Manager_API_Client {
     $meta_data = array();
     $limit_pages = false;
     $page = 1;
+    /* NULL args are interpreted as strings, throwing errors. Force it to be
+     * an array.
+     */
+    if (empty($args)) {
+      $args = array();
+    }
     if (empty($args['page'])) {
       /* if we get no specific page
        * start with page 1 and keep going.  */


### PR DESCRIPTION
I'm running into errors when queries don't pass along any arguments.  NULL` $args` in `get_list_data()` are being interpreted as strings instead of arrays, which results in illegal string offset errors, followed by `http_build_query()` failing in messy, unpleasant ways.

Adding this snippet of code to force empty `$args` to be an array solves it.