### PR TITLE
Cosmetic codefixes (spacing, blank lines, comment formatting)  to bri…

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -1,8 +1,17 @@
 <?php
-/* PBS Media Manager API Client
- * Authors: William Tam (tamw@wnet.org), Augustus Mayo (amayo@tpt.org), Aaron Crosman (aaron.crosman@cyberwoven.com)
+
+/**
+ * @file
+ * PBS Media Manager API Client.
+ *
+ * Authors: William Tam (tamw@wnet.org), Augustus Mayo (amayo@tpt.org),
+ * Aaron Crosman (aaron.crosman@cyberwoven.com)
  * version 1.1.1 2017-07-28
-*/
+ */
+
+/**
+ * PBS Media Manager API Client Class.
+ */
 class PBS_Media_Manager_API_Client {
   private $client_id;
   private $client_secret;
@@ -15,50 +24,102 @@ class PBS_Media_Manager_API_Client {
   public  $video_profiles;
   public  $file_types;
 
-  public function __construct($client_id = '', $client_secret = '', $base_endpoint =''){
+  /**
+   * PBS_Media_Manager_API_Client constructor.
+   *
+   * @param string $client_id
+   *   Client ID.
+   * @param string $client_secret
+   *   Client Secret.
+   * @param string $base_endpoint
+   *   Base Endpoint.
+   */
+  public function __construct($client_id = '', $client_secret = '', $base_endpoint = '') {
     $this->client_id = $client_id;
     $this->client_secret = $client_secret;
     $this->base_endpoint = $base_endpoint;
     $this->auth_string = $this->client_id . ":" . $this->client_secret;
 
-    // constants
-    $this->valid_endpoints = array('assets', 'episodes', 'specials', 'collections', 'seasons', 'remote-assets', 'shows', 'franchises', 'stations', 'changelog');
-    $this->passport_windows = array('public', 'all_members', 'station_members', 'unavailable');
+    // Constants.
+    $this->valid_endpoints = array(
+      'assets',
+      'episodes',
+      'specials',
+      'collections',
+      'seasons',
+      'remote-assets',
+      'shows',
+      'franchises',
+      'stations',
+      'changelog',
+    );
+    $this->passport_windows = array(
+      'public',
+      'all_members',
+      'station_members',
+      'unavailable',
+    );
     $this->asset_types = array('preview', 'clip', 'extra');
-    $this->episode_asset_types = array('preview', 'clip', 'extra', 'full_length');
-    $this->video_profiles = array('hd-1080p-mezzanine-16x9', 'hd-1080p-mezzanine-4x3', 'hd-mezzanine-16x9', 'hd-mezzanine-4x3');
-    $this->file_types = array('video', 'caption'); // 'image' will be added when the api can handle it properly
+    $this->episode_asset_types = array(
+      'preview',
+      'clip',
+      'extra',
+      'full_length',
+    );
+    $this->video_profiles = array(
+      'hd-1080p-mezzanine-16x9',
+      'hd-1080p-mezzanine-4x3',
+      'hd-mezzanine-16x9',
+      'hd-mezzanine-4x3',
+    );
+    $this->file_types = array('video', 'caption');
+    // 'image' will be added when the api can handle it properly.
   }
 
-
+  /**
+   * Build the curl handle.
+   *
+   * @param string $url
+   *   The URL.
+   *
+   * @return resource
+   *   The curl resource.
+   */
   private function build_curl_handle($url) {
-    if (!function_exists('curl_init')){
+    if (!function_exists('curl_init')) {
       die('the curl library is required for this client to work');
     }
     $ch = curl_init();
     if (!$ch) {
       die('could not initialize curl');
     }
-    curl_setopt($ch, CURLOPT_URL,$url);
-    // method and headers can be different, but these are always the same
+    curl_setopt($ch, CURLOPT_URL, $url);
+    // Method and headers can be different, but these are always the same.
     curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
     curl_setopt($ch, CURLOPT_USERPWD, $this->auth_string);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-    //curl_setopt($ch, CURLOPT_HEADER, TRUE);
     return $ch;
   }
 
-
+  /**
+   * Get request.
+   *
+   * @param string $query
+   *   The querystring.
+   *
+   * @return array|mixed
+   *   The result from the API.
+   */
   public function get_request($query) {
     $return = array();
     $request_url = $this->base_endpoint . $query;
     $ch = $this->build_curl_handle($request_url);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
-    $result=curl_exec($ch);
+    $result = curl_exec($ch);
     $info = curl_getinfo($ch);
     $errors = curl_error($ch);
-    curl_close ($ch);
-    $json = json_decode($result, true);
+    curl_close($ch);
+    $json = json_decode($result, TRUE);
     if (empty($json)) {
       return array('errors' => array('info' => $info, 'response' => $result));
     }
@@ -68,20 +129,33 @@ class PBS_Media_Manager_API_Client {
     return $json;
   }
 
-
-  /* main constructor for creating elements
-   * asset, episode, special, collection, season */
+  /**
+   * Main constructor for creating elements.
+   *
+   * Asset, episode, special, collection, season.
+   *
+   * @param string $parent_id
+   *    The parent id. Can also be a slug.
+   * @param string $parent_type
+   *    The parent type.
+   * @param string $type
+   *    The type.
+   * @param array $attribs
+   *    The attributes.
+   *
+   * @return array
+   *    On success returns the url path of the editable asset.
+   */
   public function create_child($parent_id, $parent_type, $type, $attribs = array()) {
-    /* on success returns the url path of the editable asset
-     * note that $parent_id can also be a slug */
+
     $endpoint = "/" . $parent_type . "s/" . $parent_id . "/" . $type . "s/";
     $data = array(
       "data" => array(
         "type" => $type,
-        "attributes" => $attribs
-      )
+        "attributes" => $attribs,
+      ),
     );
-    /* in the MM API, create is a POST */
+    /* In the MM API, create is a POST. */
     $return = array();
     $payload_json = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     $request_url = $this->base_endpoint . $endpoint;
@@ -89,23 +163,38 @@ class PBS_Media_Manager_API_Client {
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, FALSE);
     curl_setopt($ch, CURLOPT_HEADER, TRUE);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload_json);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'Content-Type: application/json', 'Content-Length: ' . strlen($payload_json)));
-    $result=curl_exec($ch);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Content-Length: ' . strlen($payload_json)));
+    $result = curl_exec($ch);
     $info = curl_getinfo($ch);
     $errors = curl_error($ch);
-    curl_close ($ch);
+    curl_close($ch);
     if (!in_array($info['http_code'], array(200, 201, 202, 204))) {
       return array('errors' => array('errors' => $errors, 'result' => $result));
     }
-    /* successful request will return a 20x and the location of the created object
-     * we'll follow that location and parse the resulting JSON to return the cid */
-    // get just the URI
+    /*
+     * A successful request will return a 20x and the location of the created
+     * object.
+     * We'll follow that location and parse the resulting JSON to return the
+     * cid.
+     */
+    // Get just the URI.
     preg_match("/(Location|URI): .*?\/([a-f0-9\-]+)\/(edit\/)?(\r|\n|\r\n)/", $result, $matches);
 
     // TODO: Unsafe indexing, how should errors be handled?
     return $matches[2];
   }
 
+  /**
+   * Get update endpoint.
+   *
+   * @param string $id
+   *   The ID.
+   * @param string $type
+   *   The type.
+   *
+   * @return string
+   *   The update endpoint.
+   */
   private function _get_update_endpoint($id, $type) {
     $endpoint = "/" . $type . "s/" . $id . "/";
     if ($type == 'asset') {
@@ -114,74 +203,144 @@ class PBS_Media_Manager_API_Client {
     return $endpoint;
   }
 
+  /**
+   * Get updatable object.
+   *
+   * @param string $id
+   *   The ID.
+   * @param string $type
+   *   The type.
+   *
+   * @return array|mixed
+   *   The updatable object.
+   */
   public function get_updatable_object($id, $type) {
     return $this->get_request(
       $this->_get_update_endpoint($id, $type)
     );
   }
 
-  /* main constructor for updating objects
-   * asset, episode, special, collection, season */
+  /**
+   * Main constructor for updating objects.
+   *
+   * Asset, episode, special, collection, season.
+   *
+   * @param string $id
+   *   The ID.
+   * @param string $type
+   *   The type.
+   * @param array $attribs
+   *   The attributes.
+   *
+   * @return array|bool
+   *   A successful request will return a 20x and nothing else.
+   */
   public function update_object($id, $type, $attribs = array()) {
-    /* in the MM API, update is a PATCH */
+    /* In the MM API, update is a PATCH. */
     $endpoint = $this->_get_update_endpoint($id, $type);
     $data = array(
       "data" => array(
         "type" => $type,
         "id" => $id,
-        "attributes" => $attribs
-      )
+        "attributes" => $attribs,
+      ),
     );
     $payload_json = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     $request_url = $this->base_endpoint . $endpoint;
     $ch = $this->build_curl_handle($request_url);
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PATCH");
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload_json);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, array( 'Content-Type: application/json', 'Content-Length: ' . strlen($payload_json)));
-    $result=curl_exec($ch);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'Content-Length: ' . strlen($payload_json)));
+    $result = curl_exec($ch);
     $info = curl_getinfo($ch);
     $errors = curl_error($ch);
-    curl_close ($ch);
+    curl_close($ch);
     if (!in_array($info['http_code'], array(200, 201, 202, 204))) {
-      return array('errors' => array('info' => $info, 'errors' => $errors, 'result' => $result));
+      return array(
+        'errors' => array(
+          'info' => $info,
+          'errors' => $errors,
+          'result' => $result,
+        ),
+      );
     }
     /* successful request will return a 20x and nothing else */
     return TRUE;
   }
 
+  /**
+   * Delete an object.
+   *
+   * @param string $id
+   *    The ID.
+   * @param string $type
+   *   The type.
+   *
+   * @return array|bool
+   *   A successful request will return a 20x and nothing else.
+   */
   public function delete_object($id, $type) {
     $endpoint = "/" . $type . "/" . $id . "/";
     $request_url = $this->base_endpoint . $endpoint;
     $ch = $this->build_curl_handle($request_url);
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-    $result=curl_exec($ch);
+    $result = curl_exec($ch);
     $info = curl_getinfo($ch);
     $errors = curl_error($ch);
-    curl_close ($ch);
+    curl_close($ch);
     if (!in_array($info['http_code'], array(200, 201, 202, 204))) {
-      return array('errors' => array('info' => $info, 'errors' => $errors, 'result' => $result));
+      return array(
+        'errors' => array(
+          'info' => $info,
+          'errors' => $errors,
+          'result' => $result,
+        ),
+      );
     }
     /* successful request will return a 20x and nothing else */
     return TRUE;
   }
 
-
-
-  /* main constructor for getting single items
-   * asset, episode, special, collection, season, show, franchise, station */
-  public function get_item_of_type($id, $type, $private=false) {
-    /* note that $id can also be a slug */
+  /**
+   * Main constructor for getting single items.
+   *
+   * Asset, episode, special, collection, season, show, franchise, station.
+   *
+   * @param string $id
+   *    The ID. Can also be a slug.
+   * @param string $type
+   *    The type.
+   * @param bool $private
+   *    Whether the item is private.
+   *
+   * @return array|mixed
+   *    The items.
+   */
+  public function get_item_of_type($id, $type, $private = FALSE) {
     $query = "/" . $type . "s/" . $id . "/";
-    // unpublished, 'private' items have to do a GET on the update endpoint
+    // Unpublished, 'private' items have to do a GET on the update endpoint.
     if ($private) {
-       $query = $this->_get_update_endpoint($id, $type);
+      $query = $this->_get_update_endpoint($id, $type);
     }
     return $this->get_request($query);
   }
 
-
-  /* main constructor for lists */
-  public function get_list_data($endpoint, $args = array(), $include_metadata = false) {
+  /**
+   * Main constructor for lists.
+   *
+   * @param string $endpoint
+   *    The endpoint.
+   * @param array $args
+   *    The arguments.  If a value is given for $args['page'], only the
+   *    page number will be returned.
+   * @param bool $include_metadata
+   *    Option to include metadata in the results.
+   *
+   * @return array
+   *   An array of list of items.
+   */
+  public function get_list_data($endpoint, $args = array(), $include_metadata
+    = FALSE) {
     /* By default only return the actual data, stripping meta and pagination
      * data including all results. If a value is given for page
      * only return page number. If include_metadata is true, return fields from
@@ -189,14 +348,15 @@ class PBS_Media_Manager_API_Client {
      */
     $result_data = array();
     $meta_data = array();
-    $limit_pages = false;
+    $limit_pages = FALSE;
     $page = 1;
     if (empty($args['page'])) {
-      /* if we get no specific page
+      /* If we get no specific page
        * start with page 1 and keep going.  */
       $args['page'] = $page;
-    } else {
-      $limit_pages = true;
+    }
+    else {
+      $limit_pages = TRUE;
     }
 
     while ($page) {
@@ -225,7 +385,8 @@ class PBS_Media_Manager_API_Client {
       if (!empty($rawdata['links']['next']) && !$limit_pages) {
         $page++;
         $args['page'] = $page;
-      } else {
+      }
+      else {
         $page = 0;
       }
     }
@@ -238,16 +399,37 @@ class PBS_Media_Manager_API_Client {
     return $result_data;
   }
 
-
-  /* main constructor for child items */
-  public function get_child_items_of_type($parent_id, $parent_type, $type, $queryargs=array()) {
-    /* note that $parent_id can also be a slug, but generally wont be */
+  /**
+   * Main constructor for child items.
+   *
+   * @param string $parent_id
+   *   Parent ID. Can also be a slug, but generally won't be.
+   * @param string $parent_type
+   *   Parent type.
+   * @param string $type
+   *   Type.
+   * @param array $queryargs
+   *   The arguments for the query.
+   *
+   * @return array
+   *   An array of items.
+   */
+  public function get_child_items_of_type($parent_id, $parent_type, $type, $queryargs = array()) {
     $query = "/" . $parent_type . "s/" . $parent_id . "/" . $type . "s/";
     return $this->get_list_data($query, $queryargs);
   }
 
-
-  /* helper function for cleaning up arguments */
+  /**
+   * Helper function for cleaning up arguments.
+   *
+   * @param string $asset_type_list
+   *   A comma-delimited list of asset types.
+   * @param string $container_type
+   *   The type of container. Defaults to episode.
+   *
+   * @return array|bool
+   *   An array of asset types.
+   */
   public function validate_asset_type_list($asset_type_list, $container_type = 'episode') {
     $valid_asset_types = $this->asset_types;
     if ($container_type == 'episode' || $container_type == 'special') {
@@ -259,20 +441,38 @@ class PBS_Media_Manager_API_Client {
     $typelist = explode(',', $asset_type_list);
     foreach ($typelist as $type) {
       if (!in_array($type, $valid_asset_types)) {
-        return false;
+        return FALSE;
       }
     }
     return $typelist;
   }
 
+  /**
+   * Main constructor for getting child assets.
+   *
+   * @param string $parent_id
+   *   Parent ID.
+   * @param string $parent_type
+   *   Parent type.
+   * @param string $asset_type
+   *   Asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The arguments for the query.
+   *
+   * @return array|bool
+   *   Returns an array of child assets.
+   */
+  public function get_child_assets($parent_id, $parent_type = 'episode', $asset_type = 'all', $window = 'all', $queryargs = array()) {
 
-  /* main constructor for getting assets */
-  public function get_child_assets($parent_id, $parent_type='episode', $asset_type='all', $window='all', $queryargs=array()) {
     $asset_types = $this->validate_asset_type_list($asset_type, $parent_type);
-    if (!$asset_types) { return false; }
+    if (!$asset_types) {
+      return FALSE;
+    }
     $windows = $this->passport_windows;
     if ($window !== 'all') {
-      // validate and construct the window arg
+      // Validate and construct the window arg.
       $requested_windows = explode(',', $window);
       foreach ($requested_windows as $req_window) {
         if (!in_array($req_window, $windows)) {
@@ -288,27 +488,37 @@ class PBS_Media_Manager_API_Client {
       return $raw_result;
     }
     foreach ($raw_result as $result) {
-      // ignore non-list data
+      // Ignore non-list data.
       if (empty($result['attributes'])) {
         continue;
       }
-      // only include the right asset_types
+      // Only include the right asset_types.
       if (!in_array($result['attributes']['object_type'], $asset_types)) {
         continue;
       }
-      // only include the right windows
-      /* not yet implemented in API
-      if (!in_array($result['attributes']['mvod_window'], $windows) ) {
-        continue;
-      }
-      */
+      // Only include the right windows.
+      /* Not yet implemented in API.
+       * if (!in_array($result['attributes']['mvod_window'], $windows) ) {
+       *   continue;
+       * }
+       */
       $result_data[] = $result;
     }
-    $result_data = empty($result_data) ? false : $result_data;
+    $result_data = empty($result_data) ? FALSE : $result_data;
     return $result_data;
   }
 
-  /* images are handled very differently from 'assets' */
+  /**
+   * Images are handled very differently from 'assets'.
+   *
+   * @param string $parent_id
+   *   Parent ID.
+   * @param string $parent_type
+   *   Parent type.
+   *
+   * @return array
+   *   Returns an array of images.
+   */
   public function get_images($parent_id, $parent_type) {
     $returnary = array();
     $parent = $this->get_item_of_type($parent_id, $parent_type);
@@ -320,37 +530,61 @@ class PBS_Media_Manager_API_Client {
 
   /* Special functions */
 
+  /**
+   * Legacy function to get assets by TP Media Object ID.
+   *
+   * @param string $tp_media_id
+   *   TP Media Object ID.
+   *
+   * @return array|mixed
+   *   Returns an asset.
+   */
   public function get_asset_by_tp_media_id($tp_media_id) {
     /* Returns the corresponding asset if it exists.  Note that they're
      * calling it tp_media_id, NOT tp_media_object_id */
     $query = "/assets/legacy/?tp_media_id=" . $tp_media_id;
     $response = $this->get_request($query);
     if (!empty($response["errors"]["info"]["http_code"]) && $response["errors"]["info"]["http_code"] == 404) {
-      // if this video is private/unpublished, retry the edit endpoint
+      // If this video is private/unpublished, retry the edit endpoint.
       preg_match("/.*?(\/assets\/.*)\/$/", $response["errors"]["info"]["url"], $output_array);
-      if (!empty($output_array[1])){
+      if (!empty($output_array[1])) {
         $response = $this->get_request($output_array[1] . "/edit/");
       }
     }
     return $response;
   }
 
+  /**
+   * Legacy function to get a show by program ID.
+   *
+   * @param string $program_id
+   *   Program ID.
+   *
+   * @return array|mixed
+   *   Returns the corresponding show if it exists.
+   */
   public function get_show_by_program_id($program_id) {
-    /* Returns the corresponding show if it exists.  Note that they're
-     * calling it content_channel_id, NOT program_id */
+    /* Note that they're calling it content_channel_id, NOT program_id */
     $query = "/shows/legacy/?content_channel_id=" . $program_id;
     return $this->get_request($query);
   }
 
+  /**
+   * Get the changelog.
+   *
+   * @param array $args
+   *   Possible elements are type (episode|asset|etc), action
+   *   (updated|deleted), id, since (timestamp in %Y-%m-%dT%H:%M:%S format).
+   *   All can be combined and multiple except 'since'.
+   *
+   * @return array
+   *   Returns the changelog.
+   */
   public function get_changelog($args = array()) {
-    /* args should be an array, possible elements are
-     * type (episode|asset|etc), action(updated|deleted), id,
-     * since (timestamp in %Y-%m-%dT%H:%M:%S format)
-     * all can be combined and multiple except 'since' */
     if (empty($args['since'])) {
-      // default 'since' to be in the last 8hrs
+      // Default 'since' to be in the last 8hrs.
       $timezone = new DateTimeZone('UTC');
-      $datetime = new DateTime("-24 hour", $timezone );
+      $datetime = new DateTime("-24 hour", $timezone);
       $since = $datetime->format('Y-m-d\TH:i:s.u\Z');
       $args['since'] = $since;
     }
@@ -358,154 +592,451 @@ class PBS_Media_Manager_API_Client {
     return $this->get_list_data($query, $args);
   }
 
-
   /* SHORTCUT FUNCTIONS */
 
-  /* shortcut functions for single items */
+  /* Shortcut functions for single items. */
 
-  public function get_asset($id, $private=false) {
+  /**
+   * Get a single asset.
+   *
+   * @param string $id
+   *   The ID.
+   * @param bool $private
+   *   Whether the asset is private.
+   *
+   * @return array|mixed
+   *   Returns the asset.
+   */
+  public function get_asset($id, $private = FALSE) {
     return $this->get_item_of_type($id, 'asset', $private);
   }
 
-  public function get_episode($id, $private=false) {
+  /**
+   * Get a single episode.
+   *
+   * @param string $id
+   *   The ID.
+   * @param bool $private
+   *   Whether the asset is private.
+   *
+   * @return array|mixed
+   *   Returns the episode.
+   */
+  public function get_episode($id, $private = FALSE) {
     return $this->get_item_of_type($id, 'episode', $private);
   }
 
-  public function get_special($id, $private=false) {
+  /**
+   * Get a single special.
+   *
+   * @param string $id
+   *   The ID.
+   * @param bool $private
+   *   Whether the asset is private.
+   *
+   * @return array|mixed
+   *   Returns the special.
+   */
+  public function get_special($id, $private = FALSE) {
     return $this->get_item_of_type($id, 'special', $private);
   }
 
+  /**
+   * Get a single collection.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the collection.
+   */
   public function get_collection($id) {
     return $this->get_item_of_type($id, 'collection');
   }
 
+  /**
+   * Get a single season.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the season.
+   */
   public function get_season($id) {
     return $this->get_item_of_type($id, 'season');
   }
 
+  /**
+   * Get a single show.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the show.
+   */
   public function get_show($id) {
     return $this->get_item_of_type($id, 'show');
   }
 
+  /**
+   * Get a single remote asset.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the asset.
+   */
   public function get_remote_asset($id) {
     return $this->get_item_of_type($id, 'remote-asset');
   }
 
+  /**
+   * Get a single franchise.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the asset.
+   */
   public function get_franchise($id) {
     return $this->get_item_of_type($id, 'franchise');
   }
 
+  /**
+   * Get a single station.
+   *
+   * @param string $id
+   *   The ID.
+   *
+   * @return array|mixed
+   *   Returns the station.
+   */
   public function get_station($id) {
     return $this->get_item_of_type($id, 'station');
   }
 
+  /* Shortcut functions for lists. */
 
-  /* shortcut functions for lists */
+  /* Special cases -- franchises and shows. */
 
-  /* special cases -- get franchises and shows.
-   * Franchises have no parent object, and shows do not
-   * have to have a parent object  */
-
-  public function get_franchises($queryargs=array()) {
+  /**
+   * Get a list of franchises.
+   *
+   * NOTE: Franchises have no parent object.
+   *
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array
+   *   Returns a list of franchises.
+   */
+  public function get_franchises($queryargs = array()) {
     $query = "/franchises/";
     return $this->get_list_data($query, $queryargs);
   }
 
-  public function get_shows($queryargs=array()) {
+  /**
+   * Get a list of shows.
+   *
+   * NOTE: Shows do not have to have a parent object.
+   *
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array
+   *   Returns a list of shows.
+   */
+  public function get_shows($queryargs = array()) {
     $query = "/shows/";
     return $this->get_list_data($query, $queryargs);
   }
 
-  /* shortcut functions for lists of child objects */
+  /* Shortcut functions for lists of child objects. */
 
-  public function get_franchise_shows($franchise_id, $queryargs=array()) {
+  /**
+   * Get the shows that belong to a specific franchise.
+   *
+   * @param string $franchise_id
+   *   The franchise ID.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array
+   *   Returns a list of shows.
+   */
+  public function get_franchise_shows($franchise_id, $queryargs = array()) {
     return $this->get_child_items_of_type($franchise_id, 'franchise', 'show', $queryargs);
   }
 
-  public function get_show_seasons($show_id, $queryargs=array()) {
+  /**
+   * Get the seasons for a specific show.
+   *
+   * @param string $show_id
+   *   The show ID.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array
+   *   Returns a list of seasons.
+   */
+  public function get_show_seasons($show_id, $queryargs = array()) {
     return $this->get_child_items_of_type($show_id, 'show', 'season', $queryargs);
   }
 
-  public function get_show_specials($show_id, $queryargs=array()) {
+  /**
+   * Get the specials for a specific show.
+   *
+   * @param string $show_id
+   *   The show ID.
+   * @param array $queryargs
+   *    The query arguments.
+   *
+   * @return array
+   *   Returns a list of specials.
+   */
+  public function get_show_specials($show_id, $queryargs = array()) {
     return $this->get_child_items_of_type($show_id, 'show', 'special', $queryargs);
   }
 
-  public function get_season_episodes($season_id, $queryargs=array()) {
+  /**
+   * Get the episodes of a specific season.
+   *
+   * @param string $season_id
+   *   The season ID.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array
+   *   Returns a list of episodes.
+   */
+  public function get_season_episodes($season_id, $queryargs = array()) {
     return $this->get_child_items_of_type($season_id, 'season', 'episode', $queryargs);
   }
 
+  /* Shortcuts for asset lists:  Note that assets can be children of a
+   * franchise, show, season, collection, special, or episode BUT can only be
+   * the child of one of them.
+   * If an asset is a child of an episode it is not a child of a show.
+   * These methods also allow filtering by asset_type and window.
+   */
 
-  /* shortcuts for asset lists:  Note that assets can be children of a franchise, show, season,
-   * collection, special, or episode BUT can only be the child of one of them --
-   * if an asset is a child of an episode it is not a child of a show.
-   * These methods also allow filtering by asset_type and window */
-
-  public function get_episode_assets($episode_id, $asset_type='all', $window='all', $queryargs=array()) {
+  /**
+   * Get episode assets.
+   *
+   * @param string $episode_id
+   *   The episode ID.
+   * @param string $asset_type
+   *   The asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array|bool
+   *   Returns a list of assets.
+   */
+  public function get_episode_assets($episode_id, $asset_type = 'all', $window = 'all', $queryargs = array()) {
     return $this->get_child_assets($episode_id, 'episode', $asset_type, $window, $queryargs);
   }
 
-  public function get_special_assets($special_id, $asset_type='all', $window='all', $queryargs=array()) {
+  /**
+   * Get special assets.
+   *
+   * @param string $special_id
+   *   The special ID.
+   * @param string $asset_type
+   *   The asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array|bool
+   *   Returns a list of special assets.
+   */
+  public function get_special_assets($special_id, $asset_type = 'all', $window = 'all', $queryargs = array()) {
     return $this->get_child_assets($special_id, 'special', $asset_type, $window, $queryargs);
   }
 
-  public function get_season_assets($season_id, $asset_type='all', $window='all', $queryargs=array()) {
+  /**
+   * Get season assets.
+   *
+   * @param string $season_id
+   *   The season ID.
+   * @param string $asset_type
+   *   The asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array|bool
+   *   Returns a list of season assets.
+   */
+  public function get_season_assets($season_id, $asset_type = 'all', $window = 'all', $queryargs = array()) {
     return $this->get_child_assets($season_id, 'season', $asset_type, $window, $queryargs);
   }
 
-  public function get_show_assets($show_id, $asset_type='all', $window='all', $queryargs=array()) {
+  /**
+   * Get show assets.
+   *
+   * @param string $show_id
+   *   The show ID.
+   * @param string $asset_type
+   *   The asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array|bool
+   *   Returns a list of show assets.
+   */
+  public function get_show_assets($show_id, $asset_type = 'all', $window = 'all', $queryargs = array()) {
     return $this->get_child_assets($show_id, 'show', $asset_type, $window, $queryargs);
   }
 
-  public function get_franchise_assets($franchise_id, $asset_type='all', $window='all', $queryargs=array()) {
+  /**
+   * Get franchise assets.
+   *
+   * @param string $franchise_id
+   *   The franchise ID.
+   * @param string $asset_type
+   *   The asset type.
+   * @param string $window
+   *   The availability window.
+   * @param array $queryargs
+   *   The query arguments.
+   *
+   * @return array|bool
+   *   Returns a list of franchise assets.
+   */
+  public function get_franchise_assets($franchise_id, $asset_type = 'all', $window = 'all', $queryargs = array()) {
     return $this->get_child_assets($franchise_id, 'franchise', $asset_type, $window, $queryargs);
   }
 
+  /* Shortcut functions for images. */
 
-  /* shortcut functions for images */
-
+  /**
+   * Get franchise images.
+   *
+   * @param string $franchise_id
+   *   The franchise ID.
+   *
+   * @return array
+   *   Returns a list of images for the franchise.
+   */
   public function get_franchise_images($franchise_id) {
     return $this->get_images($franchise_id, 'franchise');
   }
 
+  /**
+   * Get show images.
+   *
+   * @param string $show_id
+   *   The show ID.
+   *
+   * @return array
+   *   Returns a list of images for the show.
+   */
   public function get_show_images($show_id) {
     return $this->get_images($show_id, 'show');
   }
 
+  /**
+   * Get season images.
+   *
+   * @param string $season_id
+   *   The season ID.
+   *
+   * @return array
+   *   Returns a list of images for the season.
+   */
   public function get_season_images($season_id) {
     return $this->get_images($season_id, 'season');
   }
 
+  /**
+   * Get collection images.
+   *
+   * @param string $collection_id
+   *   The collection ID.
+   *
+   * @return array
+   *   Returns a list of images for the collection.
+   */
   public function get_collection_images($collection_id) {
     return $this->get_images($collection_id, 'collection');
   }
 
+  /**
+   * Get episode images.
+   *
+   * @param string $episode_id
+   *   The episode ID.
+   *
+   * @return array
+   *   Returns a list of images for the episode.
+   */
   public function get_episode_images($episode_id) {
     return $this->get_images($episode_id, 'episode');
   }
 
+  /**
+   * Get special images.
+   *
+   * @param string $special_id
+   *   The special ID.
+   *
+   * @return array
+   *   Returns a list of images for the special.
+   */
   public function get_special_images($special_id) {
     return $this->get_images($special_id, 'special');
   }
 
+  /**
+   * Get asset images.
+   *
+   * @param string $asset_id
+   *   The asset ID.
+   *
+   * @return array
+   *   Returns a list of images for the asset.
+   */
   public function get_asset_images($asset_id) {
     return $this->get_images($asset_id, 'asset');
   }
 
-  /* file ingest helpers */
+  /* File ingest helpers. */
 
-  public function delete_file_from_asset($asset_id, $type='video') {
+  /**
+   * Delete a file from an asset.
+   *
+   * @param string $asset_id
+   *   The asset ID.
+   * @param string $type
+   *   The type of asset.
+   *
+   * @return array|bool
+   *   Returns the updated object.
+   */
+  public function delete_file_from_asset($asset_id, $type = 'video') {
     /* deleting a file from an asset is just submitting a null value for it */
     if (empty($asset_id)) {
       return array('errors' => 'no asset id');
     }
-    if (! in_array($type, $this->file_types)) {
+    if (!in_array($type, $this->file_types)) {
       return array('errors' => 'invalid file type');
     }
     $attribs = array(
-      $type => null
+      $type => NULL,
     );
     return $this->update_object($asset_id, 'asset', $attribs);
   }
-
 
 }


### PR DESCRIPTION
@acrosman and I have applied to have our Drupal module gain Drupal.org security advisory coverage. https://www.drupal.org/node/2893613

The automated review is very picky about coding standards, and is throwing many, many errors about cosmetic issues, such as blank lines, improper spacing around equal signs, docblocks, etc.

This update seeks to resolve most of them, so that potential human reviewers can focus on real issues, instead of trivialities.

I did not make any breaking changes -- for example, the code review flagged every single function for not being in lowerCamel format. But since changing that would cause more problems than it would solve, I've left them as-is.

There were three suggested changes I did not make, but that I don't think would hurt anything.  However, I felt they were outside of the scope of this cosmetic cleanup.

1. In `__construct()`, `$this->valid_endpoint` was flagged as a dynamically declared field. Looking up at the class declarations, this is the only one missing from the list.  I think adding it would resolve this error.

2. In `get_request()`, `$return` and `$errors` were flagged as unused variables.

3.  In `create_child()`, `$return` was flagged as an unused variable.
