### PR TITLE
Junk cleanup

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -8,7 +8,7 @@ class PBS_Media_Manager_API_Client {
   private $client_secret;
   private $base_endpoint;
   private $auth_string;
-  public  $container_types;
+  public  $valid_endpoints;
   public  $passport_windows;
   public  $asset_types;
   public  $episode_asset_types;

--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -115,10 +115,22 @@ class PBS_Media_Manager_API_Client {
     curl_close($ch);
     $json = json_decode($result, TRUE);
     if (empty($json)) {
-      return array('errors' => array('info' => $info, 'errors' => $errors, 'response' => $result));
+      return array(
+        'errors' => array(
+          'info' => $info,
+          'errors' => $errors,
+          'response' => $result,
+        ),
+      );
     }
     if ($info['http_code'] != 200) {
-      return array('errors' => array('info' => $info, 'errors' => $errors, 'response' => $json));
+      return array(
+        'errors' => array(
+          'info' => $info,
+          'errors' => $errors,
+          'response' => $json,
+        ),
+      );
     }
     return $json;
   }
@@ -162,7 +174,13 @@ class PBS_Media_Manager_API_Client {
     $errors = curl_error($ch);
     curl_close($ch);
     if (!in_array($info['http_code'], array(200, 201, 202, 204))) {
-      return array('errors' => array('errors' => $errors, 'result' => $result));
+      return array(
+        'errors' => array(
+          'info' => $info,
+          'errors' => $errors,
+          'result' => $result,
+        ),
+      );
     }
     /*
      * A successful request will return a 20x and the location of the created

--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -59,10 +59,10 @@ class PBS_Media_Manager_API_Client {
     curl_close ($ch);
     $json = json_decode($result, true);
     if (empty($json)) {
-      return array('errors' => array('info' => $info, 'response' => $result));
+      return array('errors' => array('info' => $info, 'errors' => $errors, 'response' => $result));
     }
     if ($info['http_code'] != 200) {
-      return array('errors' => array('info' => $info, 'response' => $json));
+      return array('errors' => array('info' => $info, 'errors' => $errors, 'response' => $json));
     }
     return $json;
   }

--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -50,7 +50,6 @@ class PBS_Media_Manager_API_Client {
 
 
   public function get_request($query) {
-    $return = array();
     $request_url = $this->base_endpoint . $query;
     $ch = $this->build_curl_handle($request_url);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, TRUE);
@@ -82,7 +81,6 @@ class PBS_Media_Manager_API_Client {
       )
     );
     /* in the MM API, create is a POST */
-    $return = array();
     $payload_json = json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     $request_url = $this->base_endpoint . $endpoint;
     $ch = $this->build_curl_handle($request_url);


### PR DESCRIPTION
@jesseves @acrosman @augustuswm  This is a follow up to #15 , where besides cosmetic issues some unused vars etc were ID'd.   c4c20a9 actually changes functionality slightly, though -- the 'errors' array returned in get_request currently includes the return from curl_exec as 'return' and the return from curl_info as 'info'.  I meant to also include the return from curl_errors as 'errors' the same way I do in pretty much all of the other curl functions.  Now I do.   Since this additional array element has a string key instead of numeric, I don't see how it breaks anything, but I'll wait for some confirmation before merging.


