### PR TITLE
Ignore empty lines in response

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -119,6 +119,9 @@ class PBS_Media_Manager_API_Client {
       array_shift($data);
     }
     foreach ($data as $part) {
+      if (empty(trim($part))) {
+        continue;
+      }
       if (json_decode($part)) {
         $myarray[] = json_decode($part);
         continue;


### PR DESCRIPTION
I think this is the issue we ran in to. Based on error level I think we were getting varying results when parsing the `\r\n` line in this response. Change below ignores "empty" lines in the response when parsing. Not sure if this is the correct behavior.

```
HTTP/1.1 400 Bad Request\r\n
Server: nginx\r\n
Date: Sat, 24 Feb 2018 10:17:02 GMT\r\n
Content-Type: application/json\r\n
Content-Length: 77\r\n
Connection: keep-alive\r\n
Allow: GET, POST, HEAD, OPTIONS\r\n
Vary: Accept\r\n
X-Frame-Options: SAMEORIGIN\r\n
\r\n
{"errors":{"meta":{"ordinal":["Episode with this ordinal already exists."]}}}
```