### PR TITLE
Defining arrays before use

### DIFF
--- a/class-PBS-Media-Manager-API-Client.php
+++ b/class-PBS-Media-Manager-API-Client.php
@@ -227,6 +227,7 @@ class PBS_Media_Manager_API_Client {
      * cid.
      */
     // Get just the URI.
+    $matches = array();
     preg_match("/(Location|URI): .*?\/([a-f0-9\-]+)\/(edit\/)?(\r|\n|\r\n)/", $result, $matches);
 
     // TODO: Unsafe indexing, how should errors be handled?
@@ -609,7 +610,7 @@ class PBS_Media_Manager_API_Client {
     $returnary = array();
     $parent = $this->get_item_of_type($parent_id, $parent_type);
 
-    if (empty($response_object['data']['attributes']['images'])) {
+    if (empty($parent['data']['attributes']['images'])) {
       return $returnary;
     }
 
@@ -711,6 +712,7 @@ class PBS_Media_Manager_API_Client {
     $response = $this->get_request($query);
     if (!empty($response["errors"]["info"]["http_code"]) && $response["errors"]["info"]["http_code"] == 404) {
       // If this video is private/unpublished, retry the edit endpoint.
+      $output_array = array();
       preg_match("/.*?(\/assets\/.*)\/$/", $response["errors"]["info"]["url"], $output_array);
       if (!empty($output_array[1])) {
         $response = $this->get_request($output_array[1] . "/edit/");


### PR DESCRIPTION
There are a few places in the current library where arrays are used without being defined. These likely are triggering notices and may be full errors in some environments.

This PR just adds those definitions.

In the case of change on line 612, the value being checked was wrong, and likely breaking the entire method.